### PR TITLE
Update SINTERSTORE and SDIFFSTORE links

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -444,7 +444,7 @@ Note that calling these methods results in new sets being created
 on the fly. This is important so that you can perform further operations
 before reading the items to the client.
 
-For more information, see [SINTERSTORE](http://code.google.com/p/redis/wiki/SinterstoreCommand) and [SDIFFSTORE](http://code.google.com/p/redis/wiki/SdiffstoreCommand).
+For more information, see [SINTERSTORE](http://redis.io/commands/sinterstore) and [SDIFFSTORE](http://redis.io/commands/sdiffstore).
 
 Validations
 -----------


### PR DESCRIPTION
Point these links to the new redis.io site. The old site only points to redis.io, and not the actual command pages.
