### PR TITLE
Adding the option to add large amounts of data twice as fast

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -1459,7 +1459,23 @@ module Ohm
         add_to_indices
       end
     end
-
+    
+    # Batch create models, when needing to fill a dataset
+    # this is twice as fast (using multi block)
+    #
+    # @param [Array] models An array of Ohm::Models
+    def self.batch_create(models)
+      cur_id = models.first.class.key[:id].get.to_i
+      db.multi do
+        models.each do |model|
+          cur_id += 1
+          model.quick_create_with_id(cur_id)
+        end
+        models.first.class.key[:id].set cur_id
+      end
+    end
+    
+    
     # Create or update this object based on the state of #new?.
     #
     # @return [Ohm::Model, nil] The saved object or nil if it fails
@@ -1761,6 +1777,31 @@ module Ohm
       end
     end
 
+    # create a model with a given id, without locking for usage in a batch operation
+    # (needed for batch_create)
+    def quick_create_with_id(id)
+      @id = id
+      create_model_membership
+      write_multi
+      add_to_indices
+    end
+
+    # write operation without multi block, because the batch_create operation 
+    # is already wrapped in a multi block (normal write will raise an exception).
+    def write_multi
+      unless (attributes + counters).empty?
+        atts = (attributes + counters).inject([]) { |ret, att|
+          value = send(att).to_s
+
+          ret.push(att, value) if not value.empty?
+          ret
+        }
+        key.del
+        key.hmset(*atts.flatten) if atts.any?
+      end
+    end
+    
+    
     # Write a single attribute both locally and remotely. It's very important
     # to know that this method skips validation checks, therefore you must
     # ensure data integrity and validity in your application code.


### PR DESCRIPTION
At our company we are using Ohm to store an (intelligent) flat cache of all our products. When using this batch-operation we could fill our cache in almost twice the amount of time as previously when just saving for every record. It uses the multi block to save a batch of records in one atomic operation.

We had to create a new method for write (`write_multi`) because create also uses a multi block, and thus does not work. To create a record with an id we wrote: `create_with_id`. Maybe it could be implemented in a better way, but I think this would be an awesome to be included in Ohm by default.

PS the optimal batch size for us was around 100.
