### PR TITLE
def == should not override object equality completely. Two objects are…

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -1627,7 +1627,7 @@ module Ohm
     #
     # @return [true, false] Whether or not the passed object is equal.
     def ==(other)
-      other.kind_of?(self.class) && other.key == key
+      (other.kind_of?(self.class) && other.key == key) || super
     rescue MissingID
       false
     end


### PR DESCRIPTION
...the same if their object_ids are the same.
