### PR TITLE
Union keys when passing array to except 

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -568,7 +568,7 @@ module Ohm
     #
     def except(dict)
       MultiSet.new(
-        namespace, model, Command[:sdiffstore, command, intersected(dict)]
+        namespace, model, Command[:sdiffstore, command, unioned(dict)]
       )
     end
 
@@ -595,6 +595,10 @@ module Ohm
 
     def intersected(dict)
       Command[:sinterstore, *model.filters(dict)]
+    end
+    
+    def unioned(dict)
+      Command[:sunionstore, *model.filters(dict)]
     end
 
     def execute


### PR DESCRIPTION
Hi.
I found some strange behavior when I tried to find all models except some keys. It tried to intersect given keys (resulting in empty set) and then do (all - intersected keys). I think it is wrong, so I wrote this patch:

Instead of intersecting keys - union them when doing set.except(filters)

When doing `Model.all.except(key: %w{some ids})`
it more sense to return `all - (some + ids)`
instead of `all - (some & ids)`

Wdyt? If it is mergeable I'll make test & check if everything builds ok.
