### PR TITLE
 union operation in find method, similar to the IN Operator in SQL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,10 @@ User.find(:country => "Argentina").except(:status => "suspended")
 
 # Find all users both from Argentina and Uruguay
 User.find(:country => "Argentina").union(:country => "Uruguay")
+
+# Find all users both from Argentina and Uruguay which are activated
+User.find(:country => ["Argentina", "Uruguay"], :status => "activated")
+User.find(:status => "activated").find(:country => ["Argentina", "Uruguay"])
 ```
 
 Note that calling these methods results in new sets being created

--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -822,6 +822,8 @@ module Ohm
     #   end
     #
     #   u = User.create(name: "John", status: "pending", email: "foo@me.com")
+    #   u2 = User.create(name: "Steven", status: "pending", email: "steven@me.com")
+    #
     #   User.find(provider: "me", name: "John", status: "pending").include?(u)
     #   # => true
     #
@@ -831,7 +833,10 @@ module Ohm
     #   User.find(:tag => "python").include?(u)
     #   # => true
     #
-    #   User.find(:tag => ["ruby", "python"]).include?(u)
+    #   User.find(:tag => [["ruby", "python"]]).include?(u)
+    #   # => true
+    #
+    #   User.find(:name => ["John", "Steven"]).to_a == [u, u2]
     #   # => true
     #
     def self.find(dict)
@@ -840,7 +845,8 @@ module Ohm
       dicts = hash_product(dict)
       if dicts.size == 1
         # create a Ohm::Set if just one key-value pair was provided
-        if dicts.first.keys.size == 1
+        # but not when the value is an array
+        if dicts.first.keys.size == 1 && !dicts.first.values.first.is_a?(Array)
           return Ohm::Set.new(filters(dicts.first).first, key, self)
         end
         # do just an intersect if no hash value was an array

--- a/test/model.rb
+++ b/test/model.rb
@@ -459,9 +459,9 @@ test "finding by one entry in the enumerable" do |entry|
 end
 
 test "finding by multiple entries in the enumerable" do |entry|
-  assert Entry.find(:tag => ["foo", "bar"]).include?(entry)
-  assert Entry.find(:tag => ["bar", "baz"]).include?(entry)
-  assert Entry.find(:tag => ["baz", "oof"]).empty?
+  assert Entry.find(:tag => [["foo", "bar"]]).include?(entry)
+  assert Entry.find(:tag => [["bar", "baz"]]).include?(entry)
+  assert Entry.find(:tag => [["baz", "oof"]]).empty?
 end
 
 # Attributes of type Set


### PR DESCRIPTION
Hi

I always wanted s.th. similar like the SQL Operatorfor 'IN' for ohm.

I've implemented it now for Model.find and I was wondering if you have any thoughts about it?

In our case  we have 4 slugs and instead of doing this:

``` ruby
[slug1, slug2, slug3, slug4].each do
  object = Model.find(slug: slug, user_id: some_id)
  ...
end
```

We wanna do 

``` ruby
Model.find(slug: [slug1, slug2, slug3, slug4], user_id: some_id).each do |object|
  ...
end
```

Could there be some performance issues? What would be more performant?
I didn't run any test yet nor didn't write any. I first would like to get some other views about this subject.

Thanks
