### PR TITLE
Add attributes class method to Ohm::Model

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -1021,6 +1021,8 @@ module Ohm
     #   end
     #
     def self.attribute(name, cast = nil)
+      attributes << name unless attributes.include?(name)
+
       if cast
         define_method(name) do
           cast[@attributes[name]]
@@ -1404,6 +1406,10 @@ module Ohm
 
     def self.collections
       @collections ||= []
+    end
+
+    def self.attributes
+      @attributes ||= []
     end
 
     def self.filters(dict)

--- a/test/hash_key.rb
+++ b/test/hash_key.rb
@@ -27,3 +27,7 @@ test "on a reloaded model" do
   tag = Tag[tag.id]
   assert "Ruby" == hash[tag]
 end
+
+test "on attributes class method" do
+  assert [:name] == Tag.attributes
+end


### PR DESCRIPTION
This adds an `attributes` class variable and method to Ohm::Model that consists of an array of `attribute` keys. This is useful for scaffolding or if you need to know all your attribute keys and have an empty or partial instance. 

More specifically, I need this for Padrino's admin app generator. [Take a look at this issue for more info](https://github.com/padrino/padrino-framework/issues/1148).

Thanks,
-Ty. 
