### PR TITLE
Define the << operator in MutableSet

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -503,6 +503,8 @@ module Ohm
       db.sadd(key, model.id)
     end
 
+    alias_method :<<, :add
+
     # Remove a model directly from the set.
     #
     # Example:


### PR DESCRIPTION
This pull request defines `MutableSet#<<` as an alias of the `add` method.
