### PR TITLE
Clean up uniques when deleting

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -1345,7 +1345,8 @@ module Ohm
       transaction do |t|
         _uniques = nil
         _indices = nil
-        existing = nil
+        existing_indices = nil
+        existing_uniques = nil
 
         t.watch(*_unique_keys)
 
@@ -1354,7 +1355,8 @@ module Ohm
         t.watch(key[:_uniques]) if model.uniques.any?
 
         t.read do
-          existing = _read_attributes(model.indices) if model.indices.any?
+          existing_indices = _read_attributes(model.indices) if model.indices.any?
+          existing_uniques = _read_attributes(model.uniques) if model.uniques.any?
           _uniques = db.hgetall(key[:_uniques])
           _indices = db.smembers(key[:_indices])
         end
@@ -1362,7 +1364,8 @@ module Ohm
         t.write do
           _delete_uniques(_uniques)
           _delete_indices(_indices)
-          _delete_existing_indices(existing)
+          _delete_existing_uniques(existing_uniques)
+          _delete_existing_indices(existing_indices)
           model.collections.each { |e| db.del(key[e]) }
           db.srem(model.key[:all], id)
           db.del(key[:counters])

--- a/test/uniques.rb
+++ b/test/uniques.rb
@@ -64,7 +64,7 @@ test "removes the previous index when changing" do
   u.update(:email => "d@d.com")
 
   assert_equal nil, User.with(:email, "c@c.com")
-  assert_equal nil, User.key[:unique][:email].hget("c@c.com")
+  assert_equal nil, User.key[:uniques][:email].hget("c@c.com")
   assert_equal u, User.with(:email, "d@d.com")
 end
 
@@ -72,7 +72,7 @@ test "removes the previous index when deleting" do |u|
   u.delete
 
   assert_equal nil, User.with(:email, "a@a.com")
-  assert_equal nil, User.key[:unique][:email].hget("a@a.com")
+  assert_equal nil, User.key[:uniques][:email].hget("a@a.com")
 end
 
 test "unique virtual attribute" do


### PR DESCRIPTION
Fix for issue https://github.com/soveran/ohm/issues/85

A bug in the test where the key "unique" was used 
instead of "uniques" meant the test 
"removes the previous index when deleting" was
passing when it was in fact failing. Model.delete 
now mirrors Model.save in how it cleans up indexes
and uniques.
