### PR TITLE
Added a check to make sure a given attribute name won't overwrite an existing instance method

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -1025,6 +1025,11 @@ module Ohm
     #   end
     #
     def self.attribute(name, cast = nil)
+      if self.method_defined?(name)
+        raise ArgumentError,
+          "'#{name}' is an instance method of #{self} and can't be used as an attribute name"
+      end
+
       attributes << name unless attributes.include?(name)
 
       if cast


### PR DESCRIPTION
I ran into some trouble while modeling a dataset that included an "attributes" property on one of the models. See the following:

``` ruby
class BadModel < Ohm::Model
  attribute :attributes
end
```

This causes `Ohm::Model.attribute` to overwrite the `Ohm::Model#attributes` method and breaks the model. I just added a check on `Ohm::Model.attribute` that throws an error if your attribute name would overwrite an instance method.
