### PR TITLE
Redis #watch command accepts an array, not a splat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.yardoc
 /doc
 .rbenv-gemsets
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/lib/ohm/transaction.rb
+++ b/lib/ohm/transaction.rb
@@ -107,7 +107,7 @@ module Ohm
         store = Store.new
 
         if phase[:watch].any?
-          db.watch(*phase[:watch])
+          db.watch(phase[:watch])
         end
 
         run(phase[:read], store)


### PR DESCRIPTION
Calling Redis' `#watch` method with a splatted array when the array contains more than one element raises an exception.  `#watch` accepts an array as the first element, so there's no need to splat anyway.  This pull request removes the splat operator.  Tests look like they're passing (`bundle exec cutest ./test/*.rb`).
