### PR TITLE
Allow use of external connection object

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -98,7 +98,11 @@ module Ohm
     end
 
     def redis
-      threaded[context] ||= Redis.connect(options)
+      if options.kind_of? Hash
+        threaded[context] ||= Redis.connect(options)
+      else
+        options
+      end
     end
 
     def threaded


### PR DESCRIPTION
I use Ohm within EM::Synchrony. When using the existing implementation, it looks like connections are not closed. As I found no way to pass in an existing connection of connection pool, I thought about to mimic the behavior of Resque which allows to pass in variations of objects and thereby allows to predefine an external connection.
The test case to reproduce this:

``` ruby
require 'ohm'
require 'em-synchrony'
EM.synchrony do
  Ohm.connect(driver: :synchrony)
  puts Ohm.redis.info['connected_clients']
  (1..1000).each { Fiber.new { Ohm.redis.info }.resume }
  puts Ohm.redis.info['connected_clients']
  EM.stop
end
```

Without the synchrony driver, the amount of clients increased by 30, with synchrony, it ramps up by 1000.

With that patch, you can write the following:

``` ruby
require 'ohm'
require 'em-synchrony'
EM.synchrony do
  redis = EventMachine::Synchrony::ConnectionPool.new(size: 5) do
    ::Redis.new(driver: :synchrony)
  end
  Ohm.connect(redis)
  puts Ohm.redis.info['connected_clients']
  (1..1000).each { Fiber.new { Ohm.redis.info }.resume }
  puts Ohm.redis.info['connected_clients']
  (1..1000).each { Fiber.new { Ohm.redis.info }.resume }
  puts Ohm.redis.info['connected_clients']
  (1..1000).each { Fiber.new { Ohm.redis.info }.resume }
  puts Ohm.redis.info['connected_clients']
  EM.stop
end
```

The amount of connections stays low and stable.
