### PR TITLE
Remove count alias from size method.

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -166,7 +166,6 @@ module Ohm
     def size
       redis.call("LLEN", key)
     end
-    alias :count :size
 
     # Returns the first element of the list using LINDEX.
     def first
@@ -342,7 +341,6 @@ module Ohm
     def size
       execute { |key| redis.call("SCARD", key) }
     end
-    alias :count :size
 
     # Syntactic sugar for `sort_by` or `sort` when you only need the
     # first element.

--- a/test/enumerable.rb
+++ b/test/enumerable.rb
@@ -12,14 +12,14 @@ scope do
     [john, jane]
   end
 
-  test "Set#count doesn't do each" do
+  test "Set#size doesn't do each" do
     set = Contact.all
 
     def set.each
       raise "Failed"
     end
 
-    assert_equal 2, set.count
+    assert_equal 2, set.size
   end
 
   test "Set#each as an Enumerator" do |john, jane|
@@ -67,13 +67,13 @@ scope do
     end
   end
 
-  test "List#count doesn't do each" do |post, c1, c2|
+  test "List#size doesn't do each" do |post, c1, c2|
     list = post.comments
 
     def list.each
       raise "Failed"
     end
 
-    assert_equal 2, list.count
+    assert_equal 2, list.size
   end
 end


### PR DESCRIPTION
This is intended to avoid confusion with
the Enumerable#count behaviour.

Closes #79.
