### PR TITLE
Update #sort_by documentation. Only should be used with attributes in the hash.

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -270,9 +270,8 @@ module Ohm
   class BasicSet
     include Collection
 
-    # Allows you to sort by any field in your model.
-    #
-    # Example:
+    # Allows you to sort by any attribute in the hash, this doesn't include
+    # the +id+. If you want to sort by ID, use #sort.
     #
     #   class User < Ohm::Model
     #     attribute :name


### PR DESCRIPTION
Fixes #96.
