### PR TITLE
Update installation section on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ with the sources if you want to change some settings.
 
 If you don't have Ohm, try this:
 
-    $ [sudo] gem install ohm
+    $ [sudo] gem install ohm -v 2.0.0.rc1
 
 Or you can grab the code from [http://github.com/soveran/ohm][ohm].
 


### PR DESCRIPTION
The README shows how release candidate work, so we should recommend to install release candidate instead. We can update this when 2.0 is released.
