### PR TITLE
Update README for current release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Now, in an irb session you can test the Redis adapter directly:
     >> Ohm.redis.call "GET", "Foo"
     => "Bar"
 
+Note that the install instructions from above are for our release candidate, *not* for the current rubygems release (which is 1.3.2). If you want to use the current rubygems release just do a
+
+
+    $ [sudo] gem install ohm
+
+and from then on follow the instructions for [this release](https://github.com/soveran/ohm/tree/1.3.2/README.md).
+
 ## Connecting to a Redis database
 
 Ohm uses a lightweight Redis client called [Redic][redic]. To connect


### PR DESCRIPTION
The current README recommends installing an RC which is not compatible with the latest published version found on rubygems which I personally find counter-intuitive and confusing.
I think we should at least mention this explicitly and link to the docs for the current release.
I also think there are quite a few people who will want to use 1.3.2 in any case (me for example) since ohm-contrib doesnt work with the current RC.
