### PR TITLE
When a record is created, #id returns a string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+- When a record is created, `#id` returns a string instead of a integer.
+  This ensures ID is string everywhere:
+
+  Example:
+
+      ## Before
+
+      Meetup.create(name: "Ruby").id
+      # => 1
+
+      Meetup.find(name: "Ruby").id
+      # => "1"
+
+      ## Now
+
+      Meetup.create.id
+      # => "1"
+
+      Meetup.find(name: "Ruby").id
+      # => "1"
+
 - If an attribute is set to an empty string, Ohm won't delete the attribute.
 
   Example:

--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -186,7 +186,7 @@ module Ohm
     #
     # You may want to avoid doing this if your list has say, 10K entries.
     def include?(model)
-      ids.include?(model.id.to_s)
+      ids.include?(model.id)
     end
 
     # Replace all the existing elements of a list with a different

--- a/lib/ohm/lua/save.lua
+++ b/lib/ohm/lua/save.lua
@@ -37,7 +37,7 @@ local uniques = cmsgpack.unpack(ARGV[4])
 
 local function save(model, attrs)
   if model.id == nil then
-    model.id = redis.call("INCR", model.name .. ":id")
+    model.id = tostring(redis.call("INCR", model.name .. ":id"))
   end
 
   model.key = model.name .. ":" .. model.id

--- a/test/core.rb
+++ b/test/core.rb
@@ -6,19 +6,19 @@ class Event < Ohm::Model
 end
 
 test "assign attributes from the hash" do
-  event = Event.new(:name => "Ruby Tuesday")
+  event = Event.new(name: "Ruby Tuesday")
   assert_equal event.name, "Ruby Tuesday"
 end
 
 test "assign an ID and save the object" do
-  event1 = Event.create(:name => "Ruby Tuesday")
-  event2 = Event.create(:name => "Ruby Meetup")
+  event1 = Event.create(name: "Ruby Tuesday")
+  event2 = Event.create(name: "Ruby Meetup")
 
-  assert_equal "1", event1.id.to_s
-  assert_equal "2", event2.id.to_s
+  assert_equal "1", event1.id
+  assert_equal "2", event2.id
 end
 
 test "save the attributes in UTF8" do
- event = Event.create(:name => "32° Kisei-sen")
- assert "32° Kisei-sen" == Event[event.id].name
+ event = Event.create(name: "32° Kisei-sen")
+ assert_equal "32° Kisei-sen", Event[event.id].name
 end

--- a/test/enumerable.rb
+++ b/test/enumerable.rb
@@ -32,7 +32,7 @@ scope do
 
   test "select" do |john, jane|
     assert_equal 2, Contact.all.count
-    assert_equal [john], Contact.all.select { |c| c.id.to_s == john.id.to_s }
+    assert_equal [john], Contact.all.select { |c| c.id == john.id }
   end
 end
 

--- a/test/filtering.rb
+++ b/test/filtering.rb
@@ -165,7 +165,7 @@ scope do
 
     assert_equal 1, res.size
     assert res.map(&:mood).include?("sad")
-    assert res.map(&:book_id).include?(book2.id.to_s)
+    assert res.map(&:book_id).include?(book2.id)
   end
 
   test "@myobie usecase" do |book1, book2|

--- a/test/list.rb
+++ b/test/list.rb
@@ -69,5 +69,5 @@ test "deleting main model cleans up the collection" do |p, _, _, _|
 end
 
 test "#ids returns an array with the ids" do |post, *comments|
-  assert_equal comments.map { |c| c.id.to_s }, post.comments.ids
+  assert_equal comments.map(&:id), post.comments.ids
 end

--- a/test/model.rb
+++ b/test/model.rb
@@ -110,11 +110,11 @@ test "assign attributes from the hash" do
 end
 
 test "assign an ID and save the object" do
-  event1 = Event.create(:name => "Ruby Tuesday")
-  event2 = Event.create(:name => "Ruby Meetup")
+  event1 = Event.create(name: "Ruby Tuesday")
+  event2 = Event.create(name: "Ruby Meetup")
 
-  assert 1 == event1.id
-  assert 2 == event2.id
+  assert_equal "1", event1.id
+  assert_equal "2", event2.id
 end
 
 test "updates attributes" do
@@ -256,8 +256,8 @@ test "assign a new id to the event" do
   assert !event1.new?
   assert !event2.new?
 
-  assert 1 == event1.id
-  assert 2 == event2.id
+  assert_equal "1", event1.id
+  assert_equal "2", event2.id
 end
 
 # Saving a model

--- a/test/set.rb
+++ b/test/set.rb
@@ -25,8 +25,8 @@ end
 
 test "#ids returns an array with the ids" do
   user_ids = [
-    User.create(name: "John").id.to_s,
-    User.create(name: "Jane").id.to_s
+    User.create(name: "John").id,
+    User.create(name: "Jane").id
   ]
 
   assert_equal user_ids, User.all.ids


### PR DESCRIPTION
This ensures ID is string everywhere:

``` ruby
event = Event.create(name: "Ruby Meetup")
event.id #=> "1"

event = Event.find(name: "Ruby Meetup").first
event.id # => "1"
```
