### PR TITLE
allow for models inside a module

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -67,7 +67,7 @@ module Ohm
     def self.const(context, name)
       case name
       when Symbol, String
-        context.const_get(name)
+        context.const_get(name.to_s)
       else name
       end
     end

--- a/test/association_with_module.rb
+++ b/test/association_with_module.rb
@@ -1,0 +1,35 @@
+require_relative "helper"
+
+module Blog
+  class User < Ohm::Model
+    collection :posts, :'Blog::Post'
+  end
+  
+  class Post < Ohm::Model
+    reference :user, :'Blog::User'
+  end
+end
+
+setup do
+  u = Blog::User.create
+  p = Blog::Post.create(:user => u)
+
+  [u, p]
+end
+
+test "basic shake and bake" do |u, p|
+  assert u.posts.include?(p)
+
+  p = Blog::Post[p.id]
+  assert_equal u, p.user
+end
+
+test "memoization" do |u, p|
+  # This will read the user instance once.
+  p.user
+  assert_equal p.user, p.instance_variable_get(:@_memo)[:user]
+
+  # This will un-memoize the user instance
+  p.user = u
+  assert_equal nil, p.instance_variable_get(:@_memo)[:user]
+end


### PR DESCRIPTION
For some reason ruby doesn't like modularized constants specified as symbols.

```
> module Foo; class Bar; end; end
> Object.const_get(:'Foo::Bar')
=> NameError: wrong constant name Foo::Bar
> Object.const_get('Foo::Bar')
=> Foo::Bar
```

This commit fixes that, allowing for modularized models in associations.
