### PR TITLE
Add 'limit' argument to Ohm::Model.list

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -974,7 +974,7 @@ module Ohm
     # Note: You can't use the list until you save the model. If you try
     # to do it, you'll receive an Ohm::MissingID error.
     #
-    def self.list(name, model)
+    def self.list(name, model, limit)
       track(name)
 
       define_method name do


### PR DESCRIPTION
Gauging interest...I'm about to implement this for a project and figured I'd see if it could be useful for anyone else, if not here then maybe in `ohm/contrib`

This PR would add a 3rd `limit` argument to a list association that would simply `LPOP` the first/oldest id in a list association once the limit is exceeded.

Example:

``` ruby
Activity = Class.new Ohm::Model

class Feed < Ohm::Model
  list :activities, :Activity, limit: 2
end

feed = Feed.create
activity1 = Activity.create
activity2 = Activity.create
activity3 = Activity.create

feed.activities.push activity1
feed.activities.push activity2
feed.activities.push activity3

feed.activities.size #=> 2
feed.activities.include? activity1 #=> false
```
