### PR TITLE
Share mutex between all Ohm::Model classes to avoid bad mix of data on multi-threading execution

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -794,7 +794,7 @@ module Ohm
     end
 
     def self.mutex
-      @mutex ||= Mutex.new
+      @@mutex ||= Mutex.new
     end
 
     def self.synchronize(&block)


### PR DESCRIPTION
With current approach of separated of mutex per Ohm::Model class, while they still use the same redis connection, when data is being loaded by different model in a multi-threading environment, bad mix of data from 2 or more models is returned for a model to handle, which leads to problem. This pull request forces all Ohm::Model sub classes to share the same mutex to solve that issues. The fix is just 1 character('@') and the rest is just a way to craft exception to communicate more details to developer to get an understand of what's going on.
