### PR TITLE
Adds support for namespaced associations

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -67,7 +67,12 @@ module Ohm
     def self.const(context, name)
       case name
       when Symbol, String
-        context.const_get(name)
+        name = name.to_s.split('::')
+        while chunk = name.shift
+          next if chunk.empty?
+          context = context.const_get(chunk)
+        end
+        context
       else name
       end
     end

--- a/test/association_namespacing.rb
+++ b/test/association_namespacing.rb
@@ -1,0 +1,25 @@
+require_relative "helper"
+
+module Foo
+  class User < Ohm::Model
+    collection :posts, :'Foo::Post'
+  end
+
+  class Post < Ohm::Model
+    reference :user, :'Foo::User'
+  end
+end
+
+setup do
+  u = Foo::User.create
+  p = Foo::Post.create(:user => u)
+
+  [u, p]
+end
+
+test "forward association" do |u, p|
+  assert u.posts.include?(p)
+
+  p = Foo::Post[p.id]
+  assert_equal u, p.user
+end


### PR DESCRIPTION
Allow this to work:

``` ruby
module Foo
  class User < Ohm::Model
    collection :posts, :'Foo::Post'
  end

  class Post < Ohm::Model
    reference :user, :'Foo::User'
  end
end
```
