### PR TITLE
Fixing examples

### DIFF
--- a/examples/one-to-many.rb
+++ b/examples/one-to-many.rb
@@ -29,11 +29,11 @@ require "ohm"
 
 # We define both a `Video` and `Audio` model, with a `list` of *comments*.
 class Video < Ohm::Model
-  list :comments, Comment
+  list :comments, :Comment
 end
 
 class Audio < Ohm::Model
-  list :comments, Comment
+  list :comments, :Comment
 end
 
 # The `Comment` model for this example will just contain one attribute called
@@ -65,10 +65,10 @@ test "adding all sorts of comments" do
   audio.comments.push(audio_comment)
 
   assert video.comments.include?(video_comment)
-  assert video.comments.size == 1
+  assert_equal video.comments.size, 1
 
   assert audio.comments.include?(audio_comment)
-  assert audio.comments.size == 1
+  assert_equal audio.comments.size, 1
 end
 
 
@@ -100,14 +100,8 @@ test "getting paged chunks of comments" do
 
   20.times { |i| video.comments.push(Comment.create(:body => "C#{i + 1}")) }
 
-  assert %w(C1 C2 C3 C4 C5)      ==  video.comments[0, 4].map(&:body)
-  assert %w(C6 C7 C8 C9 C10)     ==  video.comments[5, 9].map(&:body)
-
-  # ** Range style is also supported.
-  assert %w(C11 C12 C13 C14 C15) ==  video.comments[10..14].map(&:body)
-
-  # ** Also you can just pass in a single number.
-  assert "C16" == video.comments[15].body
+  assert_equal %w(C1 C2 C3 C4 C5),  video.comments.range(0, 4).map(&:body)
+  assert_equal %w(C6 C7 C8 C9 C10), video.comments.range(5, 9).map(&:body)
 end
 
 #### Caveats
@@ -121,4 +115,4 @@ end
 # `SORTED SET`, and to use the timestamp (or the negative of the timestamp) as
 # the score to maintain the desired order. Deleting a comment from a
 # `SORTED SET` would be a simple
-# [ZREM](http://code.google.com/p/redis/wiki/ZremCommand) call.
+# [ZREM](http://redis.io/commands/zrem) call.

--- a/makefile
+++ b/makefile
@@ -1,4 +1,9 @@
-.PHONY: test
+.PHONY: all test examples
+
+all: test examples
 
 test:
 	cutest -r ./test/helper.rb ./test/*.rb
+
+examples:
+	RUBYLIB="./lib" cutest ./examples/*.rb


### PR DESCRIPTION
I've fixed the broken examples as explained #187 and add a task in the make file to prevent them break again.

I've added the `RUBYLIB` environment variable to prevent it using the installed gem. There are several warnings when run with `$verbose` but could not fix that.

Hope it helps, but I'm open to critics.