### PR TITLE
User redis' run_id instead of url

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -1346,7 +1346,8 @@ module Ohm
     # Run lua scripts and cache the sha in order to improve
     # successive calls.
     def script(file, *args)
-      cache = LUA_CACHE[redis.url]
+      redis_uid = redis.call("INFO")["run_id"]
+      cache = LUA_CACHE[redis_uid]
 
       if cache.key?(file)
         sha = cache[file]


### PR DESCRIPTION
My redis client does not respond to `#url` method (I'm using [Redis Failover](https://github.com/ryanlecompte/redis_failover) and [Redis Namespace](https://github.com/resque/redis-namespace))
So I've changed it by `run_id`. According to [documentation](http://redis.io/commands/info):

> run_id: Random value identifying the Redis server (to be used by Sentinel and Cluster)

As a side effect it makes extra call to redis :(