### PR TITLE
Update msgpack version.

### DIFF
--- a/ohm.gemspec
+++ b/ohm.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency "redic", "~> 1.5.0"
   s.add_dependency "nido"
   s.add_dependency "stal"
-  s.add_dependency "msgpack", "~> 0.5.0"
+  s.add_dependency "msgpack", "~> 0.5"
 
   s.add_development_dependency "cutest"
 end


### PR DESCRIPTION
We can't use disc and ohm in the same project:

```
Bundler could not find compatible versions for gem "msgpack":
  In snapshot (Gemfile.lock):
    msgpack (= 0.6.2)

  In Gemfile:
    ohm (= 2.3.0) ruby depends on
      msgpack (~> 0.5.0) ruby

    disc (= 0.0.22) ruby depends on
      msgpack (~> 0.6.1) ruby
```

Msgpack was updated in this commit: https://github.com/soveran/ohm/commit/ceea7bffccd16d4b242e905aec07e5d252503543