### PR TITLE
Uses ZRANGEBYSCORE instead of ZRANGE

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -600,7 +600,7 @@ module Ohm
       ranking = sprintf("%s:_rankings:%s", model.name, att)
 
       Ohm::Set.new(
-        model, namespace, [:ZRANGE, [:ZINTER, 2, ranking, key], start, stop]
+        model, namespace, [:ZRANGEBYSCORE, [:ZINTER, 2, ranking, key], start, stop]
       ).to_a
     end
 

--- a/test/rank.rb
+++ b/test/rank.rb
@@ -1,0 +1,24 @@
+require_relative "helper"
+
+class User < Ohm::Model
+  attribute :age
+
+  rank :age
+end
+
+setup do
+  john = User.create(:age => 10)
+  jane = User.create(:age => 15)
+
+  [john, jane]
+end
+
+test "findability" do |john, jane|
+  assert_equal 0, User.all.rank(:age, 0, 3).count
+
+  assert_equal 1, User.all.rank(:age, 9, 11).count
+  assert User.all.rank(:age, 9, 11).include?(john)
+
+  assert_equal 1, User.all.rank(:age, 14, 16).count
+  assert User.all.rank(:age, 9, 11).include?(john)
+end


### PR DESCRIPTION
Found this bug while testing the feature out:

```ruby
class User < Ohm::Model
  attribute :age
  rank :age
end

u = User.create(age: 10)

u.id #=> 1
User.all.rank(:age, 9, 11) #=> []
User.all.rank(:age, 0, 1) #=> [#<User:...>]
```

Using `ZRANGE` instead of `ZRANGEBYSCORE` means the comparisons were being made against the model id instead of the ranked attribute.