### PR TITLE
Uses keyword arguments for #rank and #range

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -573,7 +573,7 @@ module Ohm
       )
     end
 
-    # Intersect the set with a sorted set defined by :att and return
+    # Intersect the set with a sorted set defined by :by and return
     # the result of calling `to_a` on the new set.
     #
     # Example:
@@ -591,18 +591,18 @@ module Ohm
     #   ...
     #
     #   # Fetch from element 0 to element 10 (inclusive).
-    #   Country.all.rank(:population, 0, 10)
+    #   Country.all.rank(by: :population, start: 0, stop: 10)
     #
     #   # It can be appended at the end of any query.
-    #   Country.find(continent: "Asia").rank(:population, 0, 5)
+    #   Country.find(continent: "Asia").rank(by: :population, start: 0, stop: 5)
     #
-    def rank(att, start, stop)
+    def rank(by:, start:, stop:)
       Ohm::Set.new(
-        model, namespace, [:ZRANGE, ranking(att), start, stop]
+        model, namespace, [:ZRANGE, ranking(by), start, stop]
       ).to_a
     end
 
-    # Intersect the set with a sorted set defined by :att and return
+    # Intersect the set with a sorted set defined by :by and return
     # the result of calling `to_a` on the new set.
     #
     # Example:
@@ -620,14 +620,14 @@ module Ohm
     #   ...
     #
     #   # Fetch elements with score between 100 and 200.
-    #   Player.all.range(:score, 100, 200)
+    #   Player.all.range(by: :score, min: 100, max: 200)
     #
     #   # It can be appended at the end of any query.
-    #   Player.find(sport: "Archery").rank(:score, 100, 200)
+    #   Player.find(sport: "Archery").rank(by: :score, min: 100, max: 200)
     #
-    def range(att, min, max)
+    def range(by:, min:, max:)
       Ohm::Set.new(
-        model, namespace, [:ZRANGEBYSCORE, ranking(att), min, max]
+        model, namespace, [:ZRANGEBYSCORE, ranking(by), min, max]
       ).to_a
     end
 

--- a/test/filtering.rb
+++ b/test/filtering.rb
@@ -202,7 +202,7 @@ scope do
   end
 
   test "rank all items" do
-    list = Player.all.rank(:score, 0, 10)
+    list = Player.all.rank(by: :score, start: 0, stop: 10)
 
     assert_equal Player[1], list[0]
     assert_equal Player[3], list[1]
@@ -211,7 +211,7 @@ scope do
   end
 
   test "rank selected items" do
-    list = Player.find(sport: "foo").rank(:score, 0, 10)
+    list = Player.find(sport: "foo").rank(by: :score, start: 0, stop: 10)
 
     assert_equal Player[1], list[0]
     assert_equal Player[3], list[1]
@@ -219,7 +219,7 @@ scope do
   end
 
   test "range" do
-    list = Player.all.range(:score, 2, 3)
+    list = Player.all.range(by: :score, min: 2, max: 4)
 
     assert_equal Player[3], list[0]
     assert_equal Player[4], list[1]


### PR DESCRIPTION
This allows for a slightly nicer API:

```ruby
Player.all.rank(by: :score, start: 0, stop: 10)
```

It does, however, mean Ohm would no longer work in versions of Ruby that don't support the required keyword argument syntax (meaning, below 2.1), but this should be okay considering support for Ruby 2.0 has [officially ended last year](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/).

