### PR TITLE
Add Model#exists? method to detect deleted records

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -1188,7 +1188,8 @@ module Ohm
       @attributes[att] = val
     end
 
-    # Returns +true+ if the model is not persisted. Otherwise, returns +false+.
+    # Returns +true+ if the model has never been persisted. Otherwise, returns
+    # +false+.
     #
     # Example:
     #
@@ -1206,6 +1207,36 @@ module Ohm
     #
     def new?
       !defined?(@id)
+    end
+
+    # Returns +true+ if the model is persisted. Otherwise, returns +false+.
+    #
+    # Example:
+    #
+    #   class User < Ohm::Model
+    #     attribute :name
+    #   end
+    #
+    #   u = User.new(:name => "John")
+    #   u.new?
+    #   # => true
+    #   u.exists?
+    #   # => false
+    #
+    #   u.save
+    #   u.new?
+    #   # => false
+    #   u.exists?
+    #   # => true
+    #
+    #   u.delete
+    #   u.new?
+    #   # => false
+    #   u.exists?
+    #   # => false
+    #
+    def exists?
+      !new? && self.class.exists?(id)
     end
 
     # Increments a counter atomically. Internally uses `HINCRBY`.

--- a/test/model.rb
+++ b/test/model.rb
@@ -280,6 +280,23 @@ test "assign a new id to the event" do
   assert_equal "2", event2.id
 end
 
+test "event shows the correct states" do
+  event = Event.new
+
+  assert event.new?
+  assert !event.exists?
+
+  event.save
+
+  assert !event.new?
+  assert event.exists?
+
+  event.delete
+
+  assert !event.new?
+  assert !event.exists?
+end
+
 # Saving a model
 test "create the model if it is new" do
   event = Event.new(:name => "Foo").save


### PR DESCRIPTION
Disambiguate between records that have been created-but-not-persisted,
created-and-persisted, persisted-and-deleted.