### PR TITLE
Update ohm.rb

### DIFF
--- a/lib/ohm.rb
+++ b/lib/ohm.rb
@@ -703,13 +703,15 @@ module Ohm
     def self.redis
       defined?(@redis) ? @redis : Ohm.redis
     end
-
+    
+    @mutex = Mutex.new
+    
     def self.mutex
-      @@mutex ||= Mutex.new
+      @mutex
     end
 
     def self.synchronize(&block)
-      mutex.synchronize(&block)
+      @mutex.synchronize(&block)
     end
 
     # Returns the namespace for all the keys generated using this model.


### PR DESCRIPTION
Don't lazy initialize mutex, it's not thread safe.

If you intended to have one unique mutex per class (e.g. derived classes have a unique mutex) I believe something like this is required... 

```ruby
class Model
	@mutex = Mutex.new
	
	def self.inherited(derived)
		derived.instance_variable_set(:@mutex, Mutex.new)
	end
	
	def self.mutex
		@mutex
	end
	
	def self.synchronize(&block)
		mutex.synchronize(&block)
	end
end

class MyModel < Model
end

# These are both different:
pp Model.mutex
pp MyModel.mutex
```