### PR TITLE
Housekeeping

### DIFF
--- a/.gems
+++ b/.gems
@@ -1,4 +1,0 @@
-nest -v 3.1.1
-redic -v 1.5.1
-cutest -v 1.2.3
-stal -v 0.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 on:
   pull_request:
-  push: { branches: master }
+  push:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+on:
+  pull_request:
+  push: { branches: master }
+
+jobs:
+  test:
+    name: Ruby ${{ matrix.ruby }}
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: { ruby: ['2.7', '3.0', '3.1', 'head'] }
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with: 
+        ruby-version: '${{ matrix.ruby }}'
+        bundler-cache: true
+
+    - name: Run primary tests
+      run: make test
+
+    - name: Run example tests
+      run: make examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
     strategy:
       matrix: { ruby: ['2.7', '3.0', '3.1', 'head'] }
 
+    services:
+      redis:
+        image: redis
+        ports: ["6379:6379"]
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 on:
   pull_request:
-  push:
+  push: { branches: master }
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.gs
 /.yardoc
 /doc
-/.gs
+/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'cutest'
+gem 'ohm-contrib'
+
+gemspec

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@
 all: test
 
 test:
-	cutest -r ./test/helper.rb ./test/*.rb
+	bundle exec cutest -r ./test/helper.rb ./test/*.rb
 
 examples:
-	RUBYLIB="./lib" cutest ./examples/*.rb
+	RUBYLIB="./lib" bundle exec cutest ./examples/*.rb

--- a/ohm.gemspec
+++ b/ohm.gemspec
@@ -7,12 +7,15 @@ Gem::Specification.new do |s|
   s.email = ["michel@soveran.com", "djanowski@dimaion.com", "me@cyrildavid.com"]
   s.homepage = "http://soveran.github.io/ohm/"
   s.license = "MIT"
+  s.required_ruby_version = '>= 2.7.0'
 
   s.files = `git ls-files`.split("\n")
 
   s.rubyforge_project = "ohm"
 
-  s.add_dependency "redic", "~> 1.5.0"
   s.add_dependency "nest", "~> 3"
+  s.add_dependency "redic", "~> 1.5.0"
   s.add_dependency "stal"
+
+  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/ohm.gemspec
+++ b/ohm.gemspec
@@ -15,6 +15,4 @@ Gem::Specification.new do |s|
   s.add_dependency "redic", "~> 1.5.0"
   s.add_dependency "nest", "~> 3"
   s.add_dependency "stal"
-
-  s.add_development_dependency "cutest"
 end


### PR DESCRIPTION
A minor Housekeeping PR, including these changes:

1. Add `Gemfile`, gitignore `Gemfile.lock` and remove `.gems` - according to modern common practices for gem development.
2. Remove development requirement from gemspec, and add them to `Gemfile` instead.
3. Add GitHub Actions test workflow, for Ruby 2.7 and up.
4. Update gemspec with best practices options:
   - Add `rubygems_mfa_required`
   - Add `required_ruby_version` - set to the oldest, non-EoL ruby 2.7
5. Prefix `makefile` tasks with `bundle exec` so they can properly run in any Ruby setup.
